### PR TITLE
Approx median fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Expects a list of dictionaries that divide the full range of data values into co
         dict(min=150000, max=199999, n=6931136, moe=37236),
         dict(min=200000, max=1000000, n=7465517, moe=42206)
     ]
-    >>> approximate_mean(income)
+    >>> census_data_aggregator.approximate_mean(income)
     (98045.44530685373, 194.54892406267754)
 
 Note that this function expects you to submit a lower bound for the smallest bin and an upper bound for the largest bin. This is often not available for ACS datasets like income. We recommend experimenting with different lower and upper bounds to assess its effect on the resulting mean.
@@ -110,7 +110,7 @@ The simulation assumes a uniform distribution of values within each bin. In some
 
 .. code-block:: python
 
-     >>> approximate_mean(income, pareto=True)
+     >>> census_data_aggregator.approximate_mean(income, pareto=True)
      (60364.96525340687, 58.60735554621351)
 
 Also, due to the stochastic nature of the simulation approach, you will need to set a seed before running this function to ensure replicability.
@@ -119,10 +119,10 @@ Also, due to the stochastic nature of the simulation approach, you will need to 
 
      >>> import numpy
      >>> numpy.random.seed(711355)
-     >>> approximate_mean(income, pareto=True)
+     >>> census_data_aggregator.approximate_mean(income, pareto=True)
      (60364.96525340687, 58.60735554621351)
      >>> numpy.random.seed(711355)
-     >>> approximate_mean(income, pareto=True)
+     >>> census_data_aggregator.approximate_mean(income, pareto=True)
      (60364.96525340687, 58.60735554621351)
 
 
@@ -151,7 +151,7 @@ Expects a list of dictionaries that divide the full range of data values into co
 .. code-block:: python
 
   >>> household_income_la_2013_acs1 = [
-      dict(min=2499, max=9999, n=1382),
+      dict(min=0, max=9999, n=1382),
       dict(min=10000, max=14999, n=2377),
       dict(min=15000, max=19999, n=1332),
       dict(min=20000, max=24999, n=3129),
@@ -166,7 +166,7 @@ Expects a list of dictionaries that divide the full range of data values into co
       dict(min=100000, max=124999, n=5257),
       dict(min=125000, max=149999, n=3485),
       dict(min=150000, max=199999, n=2926),
-      dict(min=200000, max=250001, n=4215)
+      dict(min=200000, max=500000, n=4215)
   ]
 
 For a margin of error to be returned, a sampling percentage must be provided to calculate the standard error. The sampling percentage represents what proportion of the population that participated in the survey. Here are the values for some common census surveys.
@@ -187,14 +187,14 @@ For a margin of error to be returned, a sampling percentage must be provided to 
 
 .. code-block:: python
 
-    >>> census_data_aggregator.approximate_median(household_income_Los_Angeles_County_2013_acs1, sampling_percentage=2.5)
+    >>> census_data_aggregator.approximate_median(household_income_la_2013_acs1, sampling_percentage=2.5)
     70065.84266055046, 3850.680465234964
 
 If you do not provide the value to the function, no margin of error will be returned.
 
 .. code-block:: python
 
-  >>> census_data_aggregator.approximate_median(household_income_Los_Angeles_County_2013_acs1)
+  >>> census_data_aggregator.approximate_median(household_income_la_2013_acs1)
   70065.84266055046, None
 
 If the data being approximated comes from PUMS, an additional design factor must also be provided. 
@@ -230,7 +230,7 @@ Jam values will not be used in the simulation approach. If the estimated median 
         ]
      >>> import numpy
      >>> numpy.random.seed(711355)
-     >>> approximate_median(moe_example, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=[2499, 200001])
+     >>> census_data_aggregator.approximate_median(moe_example, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=[2499, 200001])
      (32644.851568840597, 33.0019114324823)
 
 Approximating percent change

--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,32 @@ Then if the median falls in the first or last bin, the jam value will be returne
 If the `n` values have an associated margin of error, a simulation based approach will be used to estimate the new margin of error. The `simulations` keyword argument controls the number of simulations to run and defaults to 50.
 Jam values will not be used in the simulation approach. If the estimated median falls in the lower or upper bin, the estimate returned will be `None`.
 
+
+.. code-block:: python
+
+     >>> moe_example = [
+            dict(min=math.nan, max=9999, n=6, moe=1),
+            dict(min=10000, max=14999, n=1, moe=1),
+            dict(min=15000, max=19999, n=8, moe=1),
+            dict(min=20000, max=24999, n=7, moe=1),
+            dict(min=25000, max=29999, n=2, moe=1),
+            dict(min=30000, max=34999, n=900, moe=8),
+            dict(min=35000, max=39999, n=7, moe=1),
+            dict(min=40000, max=44999, n=4, moe=1),
+            dict(min=45000, max=49999, n=8, moe=1),
+            dict(min=50000, max=59999, n=6, moe=1),
+            dict(min=60000, max=74999, n=7, moe=1),
+            dict(min=75000, max=99999, n=2, moe=0.25),
+            dict(min=100000, max=124999, n=7, moe=1),
+            dict(min=125000, max=149999, n=10, moe=1),
+            dict(min=150000, max=199999, n=8, moe=1),
+            dict(min=200000, max=math.nan, n=18, moe=10)
+        ]
+     >>> import numpy
+     >>> numpy.random.seed(711355)
+     >>> approximate_median(moe_example, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=[2499, 200001])
+     (32644.851568840597, 33.0019114324823)
+
 Approximating percent change
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ Approximating medians
 
 Estimate a median and approximate the margin of error. Follows the U.S. Census Bureau's official guidelines for estimation. Useful for generating medians for measures like household income and age when aggregating census geographies.
 
-Expects a list of dictionaries that divide the full range of data values into continuous categories. Each dictionary should have three keys:
+Expects a list of dictionaries that divide the full range of data values into continuous categories. Each dictionary should have three keys with an optional fourth key for margin of error inputs:
 
 .. list-table::
   :header-rows: 1
@@ -139,11 +139,13 @@ Expects a list of dictionaries that divide the full range of data values into co
   * - key
     - value
   * - min
-    - The minimum value of the range
+    - The minimum value of the range (if unknown use `math.nan`)
   * - max
-    - The maximum value of the range
+    - The maximum value of the range (if unknown use `math.nan`)
   * - n
     - The number of people, households or other units in the range
+  * - moe (optional)
+    - The `n` value's associated margin of error
 
 
 .. code-block:: python
@@ -195,8 +197,15 @@ If you do not provide the value to the function, no margin of error will be retu
   >>> census_data_aggregator.approximate_median(household_income_Los_Angeles_County_2013_acs1)
   70065.84266055046, None
 
-If the data being approximated comes from PUMS, an additional design factor must also be provided. The design factor is a statistical input used to tailor the estimate to the variance of the dataset. Find the value for the dataset you are estimating by referring to `the bureau's reference material <https://www.census.gov/programs-surveys/acs/technical-documentation/pums/documentation.html>`_.
+If the data being approximated comes from PUMS, an additional design factor must also be provided. 
+The design factor is a statistical input used to tailor the estimate to the variance of the dataset. 
+Find the value for the dataset you are estimating by referring to `the bureau's reference material <https://www.census.gov/programs-surveys/acs/technical-documentation/pums/documentation.html>`_.
 
+If you have an associated "jam values" for your dataset provided in the `American Community Survey's technical documentation <https://www.documentcloud.org/documents/6165752-2017-SummaryFile-Tech-Doc.html#document/p20/a508561>`_, input the pair as a list to the `jam_values` keyword argument. 
+Then if the median falls in the first or last bin, the jam value will be returned instead of `None`.
+        
+If the `n` values have an associated margin of error, a simulation based approach will be used to estimate the new margin of error. The `simulations` keyword argument controls the number of simulations to run and defaults to 50.
+Jam values will not be used in the simulation approach. If the estimated median falls in the lower or upper bin, the estimate returned will be `None`.
 
 Approximating percent change
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/census_data_aggregator/__init__.py
+++ b/census_data_aggregator/__init__.py
@@ -170,11 +170,11 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
 
             if math.isnan(n_midpoint_range['max']) and not jam_values:
                 # Let's throw a warning
-                warnings.warn("", JamValueWarning)
+                # warnings.warn("", JamValueWarning)
                 simulation_results.append(math.nan)  # does it make sense to average these?
             elif math.isnan(n_midpoint_range['min']) and not jam_values:
                 # Let's throw a warning
-                warnings.warn("", JamValueWarning)
+                # warnings.warn("", JamValueWarning)
                 simulation_results.append(math.nan)  # does it make sense to average these?
             elif math.isnan(n_midpoint_range['max']):  # already exhausted the no jam value case
                 estimated_median = jam_values[1]
@@ -185,10 +185,20 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
             else:
                 simulation_results.append(estimated_median)
 
-        estimated_median = numpy.nanmean(simulation_results)  # should this be median of medians instead?
-        t1 = numpy.nanquantile(simulation_results, 0.95) - estimated_median  # go from confidence interval to margin of error
-        t2 = estimated_median - numpy.nanquantile(simulation_results, 0.05)  # go from confidence interval to margin of error
-        margin_of_error = max(t1, t2)   # if asymmetrical take bigger one, conservative
+        if math.nan in simulation_results:
+            estimated_median = None
+            margin_of_error = None
+        elif jam_values and jam_values[0] in simulation_results:
+            estimated_median = None
+            margin_of_error = None
+        elif jam_values and jam_values[1] in simulation_results:
+            estimated_median = None
+            margin_of_error = None
+        else:
+            estimated_median = numpy.nanmean(simulation_results)  # mean of medians
+            t1 = numpy.nanquantile(simulation_results, 0.95) - estimated_median  # go from confidence interval to margin of error
+            t2 = estimated_median - numpy.nanquantile(simulation_results, 0.05)  # go from confidence interval to margin of error
+            margin_of_error = max(t1, t2)   # if asymmetrical take bigger one, conservative
     # get the median and moe via census approximation
     else:
         # For each range calculate its min and max value along the universe's scale

--- a/census_data_aggregator/__init__.py
+++ b/census_data_aggregator/__init__.py
@@ -4,7 +4,7 @@ from __future__ import division
 import math
 import numpy
 import warnings
-from .exceptions import DataError, SamplingPercentageWarning, JamValueWarning
+from .exceptions import DataError, SamplingPercentageWarning, JamValueMissingWarning, JamValueResultWarning, JamValueResultMOEWarning
 
 
 def approximate_sum(*pairs):
@@ -191,12 +191,15 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
                 simulation_results.append(estimated_median)
         #  if jam values are involved, doesn't make sense to take a mean, return None
         if math.nan in simulation_results:
+            warnings.warn("", JamValueMissingWarning)
             estimated_median = None
             margin_of_error = None
         elif jam_values and jam_values[0] in simulation_results:
+            warnings.warn("", JamValueResultMOEWarning)
             estimated_median = None
             margin_of_error = None
         elif jam_values and jam_values[1] in simulation_results:
+            warnings.warn("", JamValueResultMOEWarning)
             estimated_median = None
             margin_of_error = None
         #  if jam values aren't involved, proceed as normal
@@ -237,18 +240,20 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
 
         if not jam_values and math.isnan(n_midpoint_range['max']):
             # Let's throw a warning
-            warnings.warn("", JamValueWarning)
+            warnings.warn("", JamValueMissingWarning)
             return None, None
 
         if not jam_values and math.isnan(n_midpoint_range['min']):
             # Let's throw a warning
-            warnings.warn("", JamValueWarning)
+            warnings.warn("", JamValueMissingWarning)
             return None, None
 
         if math.isnan(n_midpoint_range['max']):
+            warnings.warn("", JamValueResultWarning)
             estimated_median = jam_values[1]
 
         elif math.isnan(n_midpoint_range['min']):
+            warnings.warn("", JamValueResultWarning)
             estimated_median = jam_values[0]
 
         # If there's no sampling percentage, we can't calculate a margin of error

--- a/census_data_aggregator/__init__.py
+++ b/census_data_aggregator/__init__.py
@@ -4,7 +4,7 @@ from __future__ import division
 import math
 import numpy
 import warnings
-from .exceptions import DataError, SamplingPercentageWarning, JamValueMissingWarning, JamValueResultWarning, JamValueResultMOEWarning
+from .exceptions import DataError, InputError, SamplingPercentageWarning, JamValueMissingWarning, JamValueResultWarning, JamValueResultMOEWarning
 
 
 def approximate_sum(*pairs):
@@ -250,7 +250,10 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
 
         if math.isnan(n_midpoint_range['max']):
             warnings.warn("", JamValueResultWarning)
-            estimated_median = jam_values[1]
+            if len(jam_values) < 2:
+                raise InputError(f"An upper jam value input is needed")
+            else:
+                estimated_median = jam_values[1]
 
         elif math.isnan(n_midpoint_range['min']):
             warnings.warn("", JamValueResultWarning)

--- a/census_data_aggregator/__init__.py
+++ b/census_data_aggregator/__init__.py
@@ -168,23 +168,28 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
             # Estimate the median
             estimated_median = n_midpoint_range['min'] + n_midrange_gap_adjusted
 
+            #  median in last bin but no jam value input
             if math.isnan(n_midpoint_range['max']) and not jam_values:
-                # Let's throw a warning
+                # don't need warning because jam value won't appear
                 # warnings.warn("", JamValueWarning)
-                simulation_results.append(math.nan)  # does it make sense to average these?
+                simulation_results.append(math.nan)  # return nan
+            #  median in first bin but not jam value input
             elif math.isnan(n_midpoint_range['min']) and not jam_values:
-                # Let's throw a warning
+                # don't need warning because jam value won't appear
                 # warnings.warn("", JamValueWarning)
-                simulation_results.append(math.nan)  # does it make sense to average these?
+                simulation_results.append(math.nan)  # return nan
+            #  median in last bin and jam value given
             elif math.isnan(n_midpoint_range['max']):  # already exhausted the no jam value case
                 estimated_median = jam_values[1]
                 simulation_results.append(estimated_median)
+            #  median in first bin and jam value given
             elif math.isnan(n_midpoint_range['min']):  # already exhausted the no jam value case
                 estimated_median = jam_values[0]
                 simulation_results.append(estimated_median)
+            #  median is fine
             else:
                 simulation_results.append(estimated_median)
-
+        #  if jam values are involved, doesn't make sense to take a mean, return None
         if math.nan in simulation_results:
             estimated_median = None
             margin_of_error = None
@@ -194,6 +199,7 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
         elif jam_values and jam_values[1] in simulation_results:
             estimated_median = None
             margin_of_error = None
+        #  if jam values aren't involved, proceed as normal
         else:
             estimated_median = numpy.nanmean(simulation_results)  # mean of medians
             t1 = numpy.nanquantile(simulation_results, 0.95) - estimated_median  # go from confidence interval to margin of error

--- a/census_data_aggregator/__init__.py
+++ b/census_data_aggregator/__init__.py
@@ -301,6 +301,9 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
         # Calculate the margin of error at the 90% confidence level
         margin_of_error = 1.645 * standard_error_median
 
+        if math.isnan(margin_of_error):
+            margin_of_error = None
+
     # Return the result
     return estimated_median, margin_of_error
 

--- a/census_data_aggregator/__init__.py
+++ b/census_data_aggregator/__init__.py
@@ -71,12 +71,11 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
     Args:
         range_list (list): A list of dictionaries that divide the full range of data values into continuous categories.
             Each dictionary should have three keys:
-                * min (int): The minimum value of the range
-                * max (int): The maximum value of the range
+                * min (int): The minimum value of the range. If unknown use `math.nan`.
+                * max (int): The maximum value of the range. If unknown use `math.nan`.
                 * n (int): The number of people, households or other unit in the range
-            The minimum value in the first range and the maximum value in the last range
-            can be tailored to the dataset by using the "jam values" provided in
-            the `American Community Survey's technical documentation`_.
+                * moe (float, optional): If the `n` value has an associated margin of error, include it to contribute
+                to the new margin of error calculation.
         design_factor (float, optional): A statistical input used to tailor the standard error to the
             variance of the dataset. This is only needed for data coming from public use microdata sample,
             also known as PUMS. You do not need to provide this input if you are approximating
@@ -89,7 +88,11 @@ def approximate_median(range_list, design_factor=1, sampling_percentage=None, ja
             * Three-year ACS: 7.5
             * Five-year ACS: 12.5
          If you do not provide this input, a margin of error will not be returned.
-
+         jam_values (list, optional): If you have an associated "jam values" for your dataset provided in
+            the `American Community Survey's technical documentation`_ input the pair as a list. If the median falls
+            in the first or last bin, the jam value will be returned instead of `None`.
+        simulations (integer, optional): If the `n` values have an associated margin of error, a simulation based approach
+        will be used to estimate the new margin of error. This input controls the number of simulations to run. Defaults to 50.
     Returns:
         A two-item tuple with the median followed by the approximated margin of error.
 

--- a/census_data_aggregator/exceptions.py
+++ b/census_data_aggregator/exceptions.py
@@ -15,3 +15,11 @@ class SamplingPercentageWarning(Warning):
     """
     def __str__(self):
         return """A margin of error cannot be calculated unless you provide a sampling percentage."""
+
+
+class JamValueWarning(Warning):
+    """
+    Warns that you have not provided jam values when they are needed.
+    """
+    def __str__(self):
+        return """The median falls in the upper or lower bracket. Provide a jam value for more information."""

--- a/census_data_aggregator/exceptions.py
+++ b/census_data_aggregator/exceptions.py
@@ -17,9 +17,25 @@ class SamplingPercentageWarning(Warning):
         return """A margin of error cannot be calculated unless you provide a sampling percentage."""
 
 
-class JamValueWarning(Warning):
+class JamValueMissingWarning(Warning):
     """
     Warns that you have not provided jam values when they are needed.
     """
     def __str__(self):
         return """The median falls in the upper or lower bracket. Provide a jam value for more information."""
+
+
+class JamValueResultWarning(Warning):
+    """
+    Warns that the estiamte is a jam value.
+    """
+    def __str__(self):
+        return """The median falls in the upper or lower bracket. A jam value is returned as the median estimate."""
+
+
+class JamValueResultMOEWarning(Warning):
+    """
+    Warns that the estiamte is not provided because averaging jam values is inappropriate.
+    """
+    def __str__(self):
+        return """The median falls in the upper or lower bracket. No estimate is returned since an average over jam values is inappropriate."""

--- a/census_data_aggregator/exceptions.py
+++ b/census_data_aggregator/exceptions.py
@@ -9,6 +9,13 @@ class DataError(Exception):
     pass
 
 
+class InputError(Exception):
+    """
+    Raised if jam value input is invalid.
+    """
+    pass
+
+
 class SamplingPercentageWarning(Warning):
     """
     Warns that you have not provided a design factor.

--- a/test.py
+++ b/test.py
@@ -186,7 +186,7 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
             dict(min=150000, max=199999, n=8),
             dict(min=200000, max=250001, n=8)
             ]
-            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599])
+            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=[2599])
             self.assertEqual(estimate, 2599)
             self.assertEqual(moe, None)
         
@@ -209,7 +209,7 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
             dict(min=150000, max=199999, n=8),
             dict(min=200000, max=math.nan, n=186)
             ]
-            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599, 200001])
+            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=[2599, 200001])
             self.assertEqual(estimate, 200001)
             self.assertEqual(moe, None)
         
@@ -232,7 +232,7 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
             dict(min=150000, max=199999, n=8),
             dict(min=200000, max=math.nan, n=186)
             ]
-            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599])
+            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=[2599])
         
         with self.assertWarns(JamValueResultMOEWarning):
             household_income_2013_acs5 = [
@@ -253,12 +253,12 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
             dict(min=150000, max=199999, n=8, moe=1),
             dict(min=200000, max=math.nan, n=186, moe=10)
             ]
-            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599, 200001])
+            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=[2599, 200001])
             self.assertEqual(estimate, None)
             self.assertEqual(moe, None)
         
         with self.assertWarns(JamValueMissingWarning):
-            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=None)
+            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=None)
             self.assertEqual(estimate, None)
             self.assertEqual(moe, None)
         
@@ -281,7 +281,7 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
             dict(min=200000, max=math.nan, n=18, moe=10)
         ]
         numpy.random.seed(711355)
-        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=None)
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50, jam_values=None)
         self.assertAlmostEqual(estimate, 32644.851568840597)
         self.assertAlmostEqual(moe, 33.0019114324823)
         

--- a/test.py
+++ b/test.py
@@ -4,6 +4,7 @@ import doctest
 import unittest
 import census_data_aggregator
 import numpy
+import math
 from census_data_aggregator.exceptions import (
     DataError,
     SamplingPercentageWarning
@@ -115,7 +116,80 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
             census_data_aggregator.approximate_median(household_income_la_2013_acs1, sampling_percentage=2.5),
             (70065.84266055046, 3850.680465234964)
         )
-
+        
+        household_income_2013_acs5 = [
+            dict(min=2499, max=9999, n=186),
+            dict(min=10000, max=14999, n=78),
+            dict(min=15000, max=19999, n=98),
+            dict(min=20000, max=24999, n=287),
+            dict(min=25000, max=29999, n=142),
+            dict(min=30000, max=34999, n=90),
+            dict(min=35000, max=39999, n=107),
+            dict(min=40000, max=44999, n=104),
+            dict(min=45000, max=49999, n=178),
+            dict(min=50000, max=59999, n=106),
+            dict(min=60000, max=74999, n=177),
+            dict(min=75000, max=99999, n=262),
+            dict(min=100000, max=124999, n=77),
+            dict(min=125000, max=149999, n=100),
+            dict(min=150000, max=199999, n=58),
+            dict(min=200000, max=250001, n=18)
+        ]
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, jam_values=None, simulations=50)
+        self.assertAlmostEqual(estimate, 42211.096153846156)
+        self.assertAlmostEqual(moe, 4706.522752733644)
+        
+        household_income_2013_acs5 = [
+            dict(min=math.nan, max=9999, n=186),
+            dict(min=10000, max=14999, n=1),
+            dict(min=15000, max=19999, n=8),
+            dict(min=20000, max=24999, n=7),
+            dict(min=25000, max=29999, n=2),
+            dict(min=30000, max=34999, n=90),
+            dict(min=35000, max=39999, n=7),
+            dict(min=40000, max=44999, n=4),
+            dict(min=45000, max=49999, n=8),
+            dict(min=50000, max=59999, n=6),
+            dict(min=60000, max=74999, n=7),
+            dict(min=75000, max=99999, n=2),
+            dict(min=100000, max=124999, n=7),
+            dict(min=125000, max=149999, n=10),
+            dict(min=150000, max=199999, n=8),
+            dict(min=200000, max=250001, n=8)
+        ]
+        
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, jam_values=None, simulations=50)
+        self.assertEqual(estimate, None)
+        self.assertEqual(moe, None)
+        
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599])
+        self.assertEqual(estimate, 2599)
+        self.assertEqual(moe, None)
+        
+        household_income_2013_acs5 = [
+            dict(min=math.nan, max=9999, n=6),
+            dict(min=10000, max=14999, n=1),
+            dict(min=15000, max=19999, n=8),
+            dict(min=20000, max=24999, n=7),
+            dict(min=25000, max=29999, n=2),
+            dict(min=30000, max=34999, n=90),
+            dict(min=35000, max=39999, n=7),
+            dict(min=40000, max=44999, n=4),
+            dict(min=45000, max=49999, n=8),
+            dict(min=50000, max=59999, n=6),
+            dict(min=60000, max=74999, n=7),
+            dict(min=75000, max=99999, n=2),
+            dict(min=100000, max=124999, n=7),
+            dict(min=125000, max=149999, n=10),
+            dict(min=150000, max=199999, n=8),
+            dict(min=200000, max=math.nan, n=186)
+        ]
+        
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599, 200001])
+        self.assertEqual(estimate, 200001)
+        self.assertEqual(moe, None)
+        
+        
         with self.assertWarns(SamplingPercentageWarning):
             m, moe = census_data_aggregator.approximate_median(household_income_Los_Angeles_County_2013_acs5, design_factor=1.5)
             self.assertTrue(moe == None)

--- a/test.py
+++ b/test.py
@@ -189,7 +189,56 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
         self.assertEqual(estimate, 200001)
         self.assertEqual(moe, None)
         
+        household_income_2013_acs5 = [
+            dict(min=math.nan, max=9999, n=6, moe=1),
+            dict(min=10000, max=14999, n=1, moe=1),
+            dict(min=15000, max=19999, n=8, moe=1),
+            dict(min=20000, max=24999, n=7, moe=1),
+            dict(min=25000, max=29999, n=2, moe=1),
+            dict(min=30000, max=34999, n=90, moe=8),
+            dict(min=35000, max=39999, n=7, moe=1),
+            dict(min=40000, max=44999, n=4, moe=1),
+            dict(min=45000, max=49999, n=8, moe=1),
+            dict(min=50000, max=59999, n=6, moe=1),
+            dict(min=60000, max=74999, n=7, moe=1),
+            dict(min=75000, max=99999, n=2, moe=0.25),
+            dict(min=100000, max=124999, n=7, moe=1),
+            dict(min=125000, max=149999, n=10, moe=1),
+            dict(min=150000, max=199999, n=8, moe=1),
+            dict(min=200000, max=math.nan, n=186, moe=10)
+        ]
         
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599, 200001])
+        self.assertEqual(estimate, None)
+        self.assertEqual(moe, None)
+        
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=None)
+        self.assertEqual(estimate, None)
+        self.assertEqual(moe, None)
+        
+        household_income_2013_acs5 = [
+            dict(min=math.nan, max=9999, n=6, moe=1),
+            dict(min=10000, max=14999, n=1, moe=1),
+            dict(min=15000, max=19999, n=8, moe=1),
+            dict(min=20000, max=24999, n=7, moe=1),
+            dict(min=25000, max=29999, n=2, moe=1),
+            dict(min=30000, max=34999, n=900, moe=8),
+            dict(min=35000, max=39999, n=7, moe=1),
+            dict(min=40000, max=44999, n=4, moe=1),
+            dict(min=45000, max=49999, n=8, moe=1),
+            dict(min=50000, max=59999, n=6, moe=1),
+            dict(min=60000, max=74999, n=7, moe=1),
+            dict(min=75000, max=99999, n=2, moe=0.25),
+            dict(min=100000, max=124999, n=7, moe=1),
+            dict(min=125000, max=149999, n=10, moe=1),
+            dict(min=150000, max=199999, n=8, moe=1),
+            dict(min=200000, max=math.nan, n=18, moe=10)
+        ]
+        numpy.random.seed(711355)
+        estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=None)
+        self.assertAlmostEqual(estimate, 32644.851568840597)
+        self.assertAlmostEqual(moe, 33.0019114324823)
+           
         with self.assertWarns(SamplingPercentageWarning):
             m, moe = census_data_aggregator.approximate_median(household_income_Los_Angeles_County_2013_acs5, design_factor=1.5)
             self.assertTrue(moe == None)

--- a/test.py
+++ b/test.py
@@ -7,6 +7,7 @@ import numpy
 import math
 from census_data_aggregator.exceptions import (
     DataError,
+    InputError,
     SamplingPercentageWarning,
     JamValueMissingWarning,
     JamValueResultWarning,
@@ -211,6 +212,27 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
             estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599, 200001])
             self.assertEqual(estimate, 200001)
             self.assertEqual(moe, None)
+        
+        with self.assertRaises(InputError):
+            household_income_2013_acs5 = [
+            dict(min=math.nan, max=9999, n=6),
+            dict(min=10000, max=14999, n=1),
+            dict(min=15000, max=19999, n=8),
+            dict(min=20000, max=24999, n=7),
+            dict(min=25000, max=29999, n=2),
+            dict(min=30000, max=34999, n=90),
+            dict(min=35000, max=39999, n=7),
+            dict(min=40000, max=44999, n=4),
+            dict(min=45000, max=49999, n=8),
+            dict(min=50000, max=59999, n=6),
+            dict(min=60000, max=74999, n=7),
+            dict(min=75000, max=99999, n=2),
+            dict(min=100000, max=124999, n=7),
+            dict(min=125000, max=149999, n=10),
+            dict(min=150000, max=199999, n=8),
+            dict(min=200000, max=math.nan, n=186)
+            ]
+            estimate, moe = census_data_aggregator.approximate_median(household_income_2013_acs5, design_factor=1, sampling_percentage=5*2.5, simulations=50,jam_values=[2599])
         
         with self.assertWarns(JamValueResultMOEWarning):
             household_income_2013_acs5 = [


### PR DESCRIPTION
Deals with https://github.com/datadesk/census-data-aggregator/issues/17 and https://github.com/datadesk/census-data-aggregator/issues/18 

- allows moe inputs, triggers simulation of new moe
- clears up use of jam values (returned instead of None when median falls in upper or lower bin)
- plenty of warnings/errors to aid with jam value usage along with tests for these cases
